### PR TITLE
Prevent error during PUT or DELETE when data type is JSON

### DIFF
--- a/lib/rest_filters.js
+++ b/lib/rest_filters.js
@@ -52,7 +52,6 @@ module.exports.PARAMS_FILTER_METHOD_FALLBACK = function(request, next)
     if (!request.data) {
       request.data = {};
     }
-    request.data._method = request.method;
     request.headers['X-HTTP-METHOD-OVERRIDE'] = request.method;
     request.method = 'POST';
   }

--- a/lib/rest_filters.js
+++ b/lib/rest_filters.js
@@ -52,6 +52,9 @@ module.exports.PARAMS_FILTER_METHOD_FALLBACK = function(request, next)
     if (!request.data) {
       request.data = {};
     }
+    if (typeof request.data === 'object') {
+      request.data._method = request.method;
+    }
     request.headers['X-HTTP-METHOD-OVERRIDE'] = request.method;
     request.method = 'POST';
   }


### PR DESCRIPTION
When doing a `.update` or `.remove`, the `PARAMS_FILTER_METHOD_FALLBACK` filter gets called.  This happens after `request.data` has already been stringified (if using JSON as the data type).  There is a line where it is trying to treat the `request.data` as an object instead of a string.  This causes the error:

    rest_filters.js:55 Uncaught TypeError: Cannot create property '_method' on string '{"foo":"bar"}'

Checking to make sure that `request.data` is an object before attempting to set properties on it fixes this issue, although, it may not be the ideal solution if it is required to set this as a part of the data payload.  However, it does appear as if we have two `_method` params set.  Once in the URL (?_method=PUT) and one in the data portion, so I'm unsure if it's necessary to have both, as one would definitely override the other in any case.

Tested using `jake test` as well as running it in Chrome and Firefox.